### PR TITLE
PI-1563 Remove reference to missing formatNumber filter

### DIFF
--- a/src/components/probationSearch/results.njk
+++ b/src/components/probationSearch/results.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% if params.results.response.totalElements > 0 %}
-    <p>Showing {{ params.results.pagination.from | formatNumber }} to {{ params.results.pagination.to | formatNumber }} of {{ params.results.response.totalElements | formatNumber }} results.</p>
+    <p>Showing {{ params.results.pagination.from }} to {{ params.results.pagination.to }} of {{ params.results.pagination.total }} results.</p>
 {% endif %}
 
 {% if params.results.results is string %}

--- a/src/utils/pagination.test.ts
+++ b/src/utils/pagination.test.ts
@@ -17,9 +17,10 @@ describe('pagination', () => {
 
 describe('pagination from/to', () => {
   it.each([
-    { currentPage: 1, totalResults: 1, pageSize: 10, expected: { from: 1, to: 1 } },
-    { currentPage: 3, totalResults: 100, pageSize: 6, expected: { from: 13, to: 18 } },
-    { currentPage: 10, totalResults: 95, pageSize: 10, expected: { from: 91, to: 95 } },
+    { currentPage: 1, totalResults: 1, pageSize: 10, expected: { from: '1', to: '1' } },
+    { currentPage: 3, totalResults: 100, pageSize: 6, expected: { from: '13', to: '18' } },
+    { currentPage: 10, totalResults: 95, pageSize: 10, expected: { from: '91', to: '95' } },
+    { currentPage: 10, totalResults: 10000, pageSize: 1000, expected: { from: '9,001', to: '10,000' } },
   ])('should return correct from and to for page %s', ({ currentPage, totalResults, pageSize, expected }) => {
     const pagination = getPaginationLinks(currentPage, 100, totalResults, () => '', pageSize, 10)
     expect(pagination.from).toEqual(expected.from)

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -5,8 +5,9 @@ interface PageLink {
 }
 
 export interface Pagination {
-  from: number
-  to: number
+  from: string
+  to: string
+  total: string
   next?: string
   prev?: string
   items: (PageLink | { ellipsis: boolean })[]
@@ -23,8 +24,9 @@ export default function getPaginationLinks(
   const firstPage = firstPageToShow(currentPage, maxPagesToShow)
   const lastPage = lastPageToShow(currentPage, maxPagesToShow, totalPages)
   return {
-    from: (currentPage - 1) * pageSize + 1,
-    to: Math.min(currentPage * pageSize, totalResults),
+    from: ((currentPage - 1) * pageSize + 1).toLocaleString('en-GB'),
+    to: Math.min(currentPage * pageSize, totalResults).toLocaleString('en-GB'),
+    total: totalResults.toLocaleString('en-GB'),
     next: currentPage < totalPages ? pathFn(currentPage + 1) : undefined,
     prev: currentPage > 1 ? pathFn(currentPage - 1) : undefined,
     items: getPageLinks(firstPage, lastPage, currentPage, totalPages, pathFn),


### PR DESCRIPTION
The filter was available in probation-search-ui, but not in this project.